### PR TITLE
[BUGFIX] Removing deprecated "include_once"

### DIFF
--- a/Classes/Modules/Module1/index.php
+++ b/Classes/Modules/Module1/index.php
@@ -26,10 +26,5 @@
 $GLOBALS['SOBE'] = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\Localizationteam\L10nmgr\Controller\Module1::class);
 $GLOBALS['SOBE']->init();
 
-// Include files?
-foreach ($GLOBALS['SOBE']->include_once as $INC_FILE) {
-    include_once($INC_FILE);
-}
-
 $GLOBALS['SOBE']->main();
 $GLOBALS['SOBE']->printContent();

--- a/Classes/Modules/Module2List/index.php
+++ b/Classes/Modules/Module2List/index.php
@@ -250,11 +250,6 @@ class Module2List extends BaseScriptClass
 $SOBE = GeneralUtility::makeInstance(Module2List::class);
 $SOBE->init();
 
-// Include files?
-foreach ($SOBE->include_once as $INC_FILE) {
-    include_once($INC_FILE);
-}
-
 $SOBE->main();
 $SOBE->printContent();
 


### PR DESCRIPTION
This "include_once" is deprecated since TYPO3 6.2
Issue #1 