### PR TITLE
[BUGFIX] Do not use the id param for passing the configuration record…

### DIFF
--- a/Classes/Controller/ConfigurationManager.php
+++ b/Classes/Controller/ConfigurationManager.php
@@ -198,8 +198,9 @@ class ConfigurationManager extends BaseScriptClass
                 $content .= '<tr class="db_list_normal">';
                 $content .= '<td>' . $configurationDetails . '</td>';
                 $content .= '<td><a href="' . BackendUtility::getModuleUrl('ConfigurationManager_LocalizationManager', array(
-                        'id' => $record['uid'],
-                        'srcPID' => (int)$this->id
+                        'id' => $record['pid'],
+                        'srcPID' => $record['pid'],
+                        'exportUID' => $record['uid'],
                     )) . '">' . $record['title'] . '</a>' . '</td>';
                 // Get the full page path
                 // If very long, make sure to still display the full path

--- a/Classes/Controller/LocalizationManager.php
+++ b/Classes/Controller/LocalizationManager.php
@@ -230,7 +230,7 @@ class LocalizationManager extends BaseScriptClass
         // Find l10n configuration record
         /** @var $l10ncfgObj L10nConfiguration */
         $l10ncfgObj = GeneralUtility::makeInstance(L10nConfiguration::class);
-        $l10ncfgObj->load($this->id);
+        $l10ncfgObj->load((int) GeneralUtility::_GP('exportUID'));
 
         if ($l10ncfgObj->isLoaded()) {
 


### PR DESCRIPTION
The record UID is now passed as "exportUID", the id parameter set to its
PID. The srcPID parameter is keept for compatibility.

Resolves: #9